### PR TITLE
Use babel for ES6 compilation instead of reactify's builtin --es6 flag

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Snapyak
     config.active_record.raise_in_transactional_callbacks = true
 
     # use browserify to compile and package JS
-    config.browserify_rails.commandline_options = "-t [ reactify --es6 target --es5 ] --extension=\".js.jsx\""
+    config.browserify_rails.commandline_options = "-t babelify --extension=\".js.jsx\""
 
   end
 end

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-infinite-scroll": "^0.1.5"
   },
   "devDependencies": {
+    "babelify": "^6.0.2",
     "browserify": "^9.0.8",
     "browserify-incremental": "^3.0.0",
     "reactify": "^1.1.0"


### PR DESCRIPTION
Small change. It shouldn't affect anything, but it gives us some extra ES6/7 features that will be nice for async stuff.
